### PR TITLE
JWT hotfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val ArchieMateCross = crossProject(JVMPlatform, JSPlatform)
   .enablePlugins(BuildInfoPlugin)
   .settings(
     name := "ArchieMate",
-    version := "0.1.2.4",
+    version := "0.1.2.5",
     libraryDependencies ++= Seq(
       // Circe
       "io.circe" %%% "circe-core" % "0.14.10",

--- a/jvm/src/main/resources/application.conf
+++ b/jvm/src/main/resources/application.conf
@@ -103,7 +103,7 @@ archiemate {
     redirect-uri-prefix = ${?ARCHIEMATE_REDIRECT_URI_PREFIX}
   }
   new-login {
-    expiration-time = 1 minute
+    expiration-time = 5 minutes
     expiration-time = ${?TWITCH_NEW_LOGIN_TIME_TO_LOGIN}
   }
   twitch {


### PR DESCRIPTION
- Changed Java Clock usage to OffsetDateTime in JWTService
- Bonus: Extend login expiration time (in case user reads the required permissions)